### PR TITLE
Adds event listener for channel creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@
 - Works with following scopes (some may not be needed): users:read, commands, chat:write, channels:read, channels:manage, channels:join, channels:history
 - Interactivity should be enabled with redirect going to /interactive
 - Make a slash command (arbitary name) with request URL going to /commands
+- Add /events URL to events subscriptions and enable

--- a/bot.py
+++ b/bot.py
@@ -157,16 +157,22 @@ def process_interactive():
 @slack_events_adapter.on("channel_created")
 def channel_created(event_data):
     user_id = event_data["event"]["channel"]["creator"]
-    channel_name = event_data["event"]["channel"]["id"]
+
+    # channel_name is used to do logic via the name
+    channel_name = event_data["event"]["channel"]["name"]
+    
+    # channel_id is used to pass within slack messages instead of name
+    # so slack can handle private channels correctly.
+    channel_id =  event_data["event"]["channel"]["id"]
 
     user = client.users_info(user=user_id)["user"]
     username = user["name"]
 
     # Only update channel on event when it was manually created
-    if user["is_bot"] is False:
+    if channel_name.startswith("111-change-") is True and user["is_bot"] is False:
         client.chat_postMessage(
             channel="111-changes",
-            text=f"<@{username}> manually created <#{channel_name}>",
+            text=f"<@{username}> manually created <#{channel_id}>",
         )
 
 user_list = get_user_list()

--- a/bot.py
+++ b/bot.py
@@ -154,6 +154,21 @@ def process_interactive():
         return make_response("", 200)
 
 
+@slack_events_adapter.on("channel_created")
+def channel_created(event_data):
+    user_id = event_data["event"]["channel"]["creator"]
+    channel_name = event_data["event"]["channel"]["id"]
+
+    user = client.users_info(user=user_id)["user"]
+    username = user["name"]
+
+    # Only update channel on event when it was manually created
+    if user["is_bot"] is False:
+        client.chat_postMessage(
+            channel="111-changes",
+            text=f"<@{username}> manually created <#{channel_name}>",
+        )
+
 user_list = get_user_list()
 
 # Start the server on port 5000


### PR DESCRIPTION
This is used currently to announce new change channels that were not created using the bot.

Could be used in future to automate tasks when channel manually created or to keep the bot up to date with latest change number.